### PR TITLE
Success not reported if run with --repeat, uses @dataProvider and failed at first.

### DIFF
--- a/src/Extensions/RepeatedTest.php
+++ b/src/Extensions/RepeatedTest.php
@@ -93,6 +93,9 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
 
         //@codingStandardsIgnoreStart
         for ($i = 1; $i <= $this->timesRepeat && !$result->shouldStop(); $i++) {
+            // Make the repeat count widely available.
+            $_ENV['PHPUnit_RepeatedTest_RepeatCount'] = $i;
+
             if ($this->onlyRepeatFailed &&
                 $i > 1 &&
                 $this->test instanceof PHPUnit_Framework_TestCase &&

--- a/tests/TextUI/repeat-onlyfailed-dataprovider.phpt
+++ b/tests/TextUI/repeat-onlyfailed-dataprovider.phpt
@@ -1,0 +1,29 @@
+--TEST--
+phpunit --repeat 3 --only-repeat-failed ../_files/DataProviderAlternateSuccessTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--repeat';
+$_SERVER['argv'][3] = '3';
+$_SERVER['argv'][4] = '--only-repeat-failed';
+$_SERVER['argv'][5] = dirname(__FILE__).'/../_files/DataProviderAlternateSuccessTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+F.S.SS
+
+Time: %s, Memory: %sMb
+
+There was 1 failure:
+
+1) DataProviderAlternateSuccessTest::testAlternateSuccess with data set #0 ('even')
+Failed at run 1.
+
+/Users/pieterdc/Sites/phpunit-kanooh/tests/_files/DataProviderAlternateSuccessTest.php:17
+
+FAILURES!
+Tests: 3, Assertions: 0, Failures: 1, Skipped: 3.

--- a/tests/_files/DataProviderAlternateSuccessTest.php
+++ b/tests/_files/DataProviderAlternateSuccessTest.php
@@ -1,0 +1,28 @@
+<?php
+class DataProviderAlternateSuccessTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider providerMethod
+     */
+    public function testAlternateSuccess($succeedOddOrEven)
+    {
+        $repeatCount = 1;
+        if (array_key_exists('PHPUnit_RepeatedTest_RepeatCount', $_ENV)) {
+            // Alternate based on which repeat count we're currently at.
+            $repeatCount = $_ENV['PHPUnit_RepeatedTest_RepeatCount'];
+        }
+        if (($repeatCount + (int) ($succeedOddOrEven == 'even')) & 1) {
+            return;
+        } else {
+            $this->fail('Failed at run ' . $repeatCount . '.');
+        }
+    }
+
+    public static function providerMethod()
+    {
+        return array(
+          array('even'),
+          array('odd')
+        );
+    }
+}


### PR DESCRIPTION
While working on #1965 I discovered that when dataProvider is used with repeat, we can not rely on lastTestFailed from this class.
In ResultPrinter, after the test succeeded in the second run, lastTestFailed is on true while it should be false.
In TestResult, which calls the ResultPrinter listener, lastTestFailed is correctly false.
Does dataprovider mangle with that?

Added a test to a separate branch to uncover this bug.

The bug makes me think of #872 '--repeat breaks \PHPUnit_Framework_MockObject_Matcher_InvokedCount' because it's also some kind of count ...
Didn't have time to invest this further, our priority is on #1965.

The following workaround doesn't suffice although the "failed status" of the test looked more trustworthy than the one from PHPUnit_TextUI_ResultPrinter while step debugging:

```
public function endTest(PHPUnit_Framework_Test $test, $time)
{
    if (($test instanceof PHPUnit_Framework_TestCase && !$test->hasFailed()) || !$this->lastTestFailed) {
```

It makes a bunch of already existing tests fail. So, it needs work.
